### PR TITLE
clarified storage account naming criteria

### DIFF
--- a/docs/AzureSuperpowers.md
+++ b/docs/AzureSuperpowers.md
@@ -3236,7 +3236,7 @@ New-AzResourceGroup -Name 'StorageExample-<YOURALIAS>' -Location USGovVirginia
 
 ### Create an Azure Storage Account
 
-1.  Storage account names must be universally unique. In this example,
+1.  Storage account names must be universally unique, **lower case** and alphanumeric(3-24 characters). In this example,
     the storage account name Aliasblobstorage is used. When this
     is listed, replace Alias with your alias, for example if your
     alias was bsmith, your storage account would be bsmithblobstorage.


### PR DESCRIPTION
clarified storage account naming criteria to avoid getting the following error:
`"xxxx is not a valid storage account name. Storage account name must be between 3 and 24 characters in length and use numbers and lower-case letters only. " `